### PR TITLE
Add flush_interval -1 to reverse_proxy

### DIFF
--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -12,6 +12,8 @@
 :3004 {
         route * {
                 docker_api_auth example/acl.yml
-                reverse_proxy unix//var/run/docker.sock
+                reverse_proxy unix//var/run/docker.sock {
+                        flush_interval -1
+                }
         }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,9 @@
 :3004 {
         route * {
                 docker_api_auth example/acl.yml
-                reverse_proxy unix//var/run/docker.sock
+                reverse_proxy unix//var/run/docker.sock {
+                        flush_interval -1
+                }
         }
 }
 ```


### PR DESCRIPTION
## Summary
- Add `flush_interval -1` to the Caddy reverse_proxy config
- Disables response buffering so Docker API streaming endpoints (attach, logs) forward container output to the client in real-time

## Test plan
- [ ] Deploy updated Caddy config and run `docker run` through the proxy — container stdout/stderr should now be visible